### PR TITLE
fix: repair profile settings server action

### DIFF
--- a/src/app/profile/actions.ts
+++ b/src/app/profile/actions.ts
@@ -1,0 +1,118 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { cookies } from 'next/headers';
+
+import { createClient } from '@/utils/supabase/server';
+
+import type { UpdateProfileFormState } from './form-state';
+
+function readField(formData: FormData, key: string): string {
+  const value = formData.get(key);
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim();
+}
+
+function validateFields(formData: FormData) {
+  const fullName = readField(formData, 'fullName');
+  const phone = readField(formData, 'phone');
+  const location = readField(formData, 'location');
+  const bio = readField(formData, 'bio');
+
+  const fieldErrors: UpdateProfileFormState['fieldErrors'] = {};
+
+  if (!fullName) {
+    fieldErrors.fullName = ['Full name is required.'];
+  } else if (fullName.length < 2) {
+    fieldErrors.fullName = ['Full name must be at least 2 characters long.'];
+  } else if (fullName.length > 120) {
+    fieldErrors.fullName = ['Full name must be 120 characters or fewer.'];
+  }
+
+  if (phone) {
+    const phonePattern = /^[+0-9()\-\s]{6,20}$/;
+    if (!phonePattern.test(phone)) {
+      fieldErrors.phone = ['Enter a valid phone number.'];
+    }
+  }
+
+  if (location && location.length > 120) {
+    fieldErrors.location = ['Location must be 120 characters or fewer.'];
+  }
+
+  if (bio && bio.length > 500) {
+    fieldErrors.bio = ['Bio must be 500 characters or fewer.'];
+  }
+
+  return {
+    fieldErrors,
+    values: {
+      fullName,
+      phone,
+      location,
+      bio,
+    },
+  };
+}
+
+export async function updateProfileAction(
+  _prevState: UpdateProfileFormState,
+  formData: FormData,
+): Promise<UpdateProfileFormState> {
+  const { fieldErrors, values } = validateFields(formData);
+
+  if (Object.keys(fieldErrors).length > 0) {
+    return {
+      status: 'error',
+      message: 'Please correct the highlighted fields.',
+      fieldErrors,
+    };
+  }
+
+  const cookieStore = cookies();
+  const supabase = await createClient(cookieStore);
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return {
+      status: 'error',
+      message: 'You need to be signed in to update your profile.',
+      fieldErrors: {},
+    };
+  }
+
+  const updates = {
+    id: user.id,
+    full_name: values.fullName,
+    phone: values.phone || null,
+    location: values.location || null,
+    bio: values.bio || null,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { error } = await supabase
+    .from('users')
+    .upsert(updates, { onConflict: 'id' });
+
+  if (error) {
+    console.error('Failed to update profile settings', error);
+    return {
+      status: 'error',
+      message: 'We could not save your profile right now. Please try again later.',
+      fieldErrors: {},
+    };
+  }
+
+  revalidatePath('/profile');
+
+  return {
+    status: 'success',
+    message: 'Profile updated successfully.',
+    fieldErrors: {},
+  };
+}

--- a/src/app/profile/form-state.ts
+++ b/src/app/profile/form-state.ts
@@ -1,0 +1,18 @@
+export type UpdateProfileFormValues = {
+  fullName: string;
+  phone: string | null;
+  location: string | null;
+  bio: string | null;
+};
+
+export type UpdateProfileFormState = {
+  status: 'idle' | 'success' | 'error';
+  message: string | null;
+  fieldErrors: Partial<Record<keyof UpdateProfileFormValues, string[]>>;
+};
+
+export const UPDATE_PROFILE_INITIAL_STATE: UpdateProfileFormState = {
+  status: 'idle',
+  message: null,
+  fieldErrors: {},
+};

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -12,6 +12,8 @@ import { MapPin, Star, Package, MessageCircle, Settings, Edit } from 'lucide-rea
 import ProductCard from '@/components/product-card-new';
 import { getProducts } from '@/lib/services/products';
 import { formatDistanceToNow } from 'date-fns';
+import ProfileSettingsForm from './profile-settings-form';
+import type { UpdateProfileFormValues } from './form-state';
 
 type ProfilePageSearchParams = {
   tab?: string;
@@ -58,6 +60,13 @@ export default async function ProfilePage({
     joinedDate: profileRow?.created_at ?? user.created_at ?? null,
     responseRate: profileRow?.response_rate ?? '--',
     isVerified: Boolean(profileRow?.is_verified),
+  };
+
+  const settingsInitialValues: UpdateProfileFormValues = {
+    fullName: profileRow?.full_name ?? user.user_metadata?.full_name ?? profileData.fullName,
+    phone: profileRow?.phone ?? user.user_metadata?.phone ?? null,
+    location: profileRow?.location ?? user.user_metadata?.location ?? null,
+    bio: profileRow?.bio ?? null,
   };
 
   const joinedLabel = profileData.joinedDate
@@ -223,20 +232,15 @@ export default async function ProfilePage({
                     <CardTitle>Account Settings</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <div className="space-y-4">
+                    <div className="space-y-6">
                       <div>
-                        <label className="text-sm font-medium">Email</label>
+                        <p className="text-sm font-medium">Account email</p>
                         <p className="text-sm text-muted-foreground">{profileData.email}</p>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Email changes are managed through your authentication provider.
+                        </p>
                       </div>
-                      {profileData.phone && (
-                        <div>
-                          <label className="text-sm font-medium">Phone</label>
-                          <p className="text-sm text-muted-foreground">{profileData.phone}</p>
-                        </div>
-                      )}
-                      <Button variant="outline" className="mt-4">
-                        Update Contact Information
-                      </Button>
+                      <ProfileSettingsForm initialValues={settingsInitialValues} />
                     </div>
                   </CardContent>
                 </Card>

--- a/src/app/profile/profile-settings-form.tsx
+++ b/src/app/profile/profile-settings-form.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useFormState, useFormStatus } from 'react-dom';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+
+import { updateProfileAction } from './actions';
+import {
+  UPDATE_PROFILE_INITIAL_STATE,
+  type UpdateProfileFormState,
+  type UpdateProfileFormValues,
+} from './form-state';
+
+type ProfileSettingsFormProps = {
+  initialValues: UpdateProfileFormValues;
+};
+
+function FieldErrors({ errors }: { errors?: string[] }) {
+  if (!errors || errors.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="space-y-1 text-sm text-destructive">
+      {errors.map((error) => (
+        <li key={error}>{error}</li>
+      ))}
+    </ul>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending ? 'Saving…' : 'Save changes'}
+    </Button>
+  );
+}
+
+export default function ProfileSettingsForm({ initialValues }: ProfileSettingsFormProps) {
+  const [state, formAction] = useFormState<UpdateProfileFormState, FormData>(
+    updateProfileAction,
+    UPDATE_PROFILE_INITIAL_STATE,
+  );
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (state.status === 'success' && state.message) {
+      toast({
+        title: 'Profile updated',
+        description: state.message,
+      });
+    }
+
+    if (state.status === 'error' && state.message && Object.keys(state.fieldErrors ?? {}).length === 0) {
+      toast({
+        title: 'Profile update failed',
+        description: state.message,
+        variant: 'destructive',
+      });
+    }
+  }, [state, toast]);
+
+  const hasGlobalError =
+    state.status === 'error' && state.message && Object.keys(state.fieldErrors ?? {}).length > 0;
+
+  return (
+    <form action={formAction} className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="fullName">Full name</Label>
+        <Input
+          id="fullName"
+          name="fullName"
+          defaultValue={initialValues.fullName}
+          placeholder="Jane Doe"
+          required
+        />
+        <FieldErrors errors={state.fieldErrors?.fullName} />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="phone">Phone (optional)</Label>
+        <Input
+          id="phone"
+          name="phone"
+          defaultValue={initialValues.phone ?? ''}
+          placeholder="+964 750 000 0000"
+        />
+        <FieldErrors errors={state.fieldErrors?.phone} />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="location">Location</Label>
+        <Input
+          id="location"
+          name="location"
+          defaultValue={initialValues.location ?? ''}
+          placeholder="Erbil, Kurdistan"
+        />
+        <FieldErrors errors={state.fieldErrors?.location} />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="bio">Bio</Label>
+        <Textarea
+          id="bio"
+          name="bio"
+          defaultValue={initialValues.bio ?? ''}
+          placeholder="Tell buyers a little about yourself."
+          rows={4}
+        />
+        <FieldErrors errors={state.fieldErrors?.bio} />
+      </div>
+
+      {state.status === 'success' && state.message ? (
+        <p className="text-sm text-green-600">{state.message}</p>
+      ) : null}
+
+      {hasGlobalError ? (
+        <p className="text-sm text-destructive">{state.message}</p>
+      ) : null}
+
+      <SubmitButton />
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- move the profile update form state into its own module so the server action no longer exports objects
- add a validated Supabase-backed `updateProfileAction` and client form to submit profile changes with feedback
- render the editable settings form inside the profile page while keeping the account email read-only

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f4c386baa4832ca5496f6625287678