### PR TITLE
feat: integrate edge search for listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 dist/
+dist-tests/
 out/
 .vercel/
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "next start -H 0.0.0.0 -p 5000",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "build:test": "tsc --project tsconfig.test.json",
+    "test": "npm run build:test && node --test --loader ./tools/test-stubs/alias-loader.mjs dist-tests",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion';
-import { getProducts, getCategories } from '@/lib/services/products';
+import { getProducts, getCategories, searchProducts } from '@/lib/services/products';
 import { NewsletterSignup } from '@/components/marketing/newsletter-signup';
 import { getServerLocale } from '@/lib/locale/server';
 import { LocaleMessages, translations } from '@/lib/locale/dictionary';
@@ -34,13 +34,30 @@ interface ProductsListProps extends SearchPageProps {
 async function ProductsList({ searchParams, messages }: ProductsListProps) {
   const params = await searchParams;
 
+  const searchTerm = params.search?.trim();
+  const productLimit = 18;
+
   const [products, categories] = await Promise.all([
-    getProducts({
-      category: params.category,
-      condition: params.condition,
-      location: params.location,
-      search: params.search,
-    }),
+    searchTerm
+      ? searchProducts(
+          {
+            category: params.category,
+            condition: params.condition,
+            location: params.location,
+            search: searchTerm,
+          },
+          productLimit,
+          0,
+          'newest'
+        ).then((result) => result.items)
+      : getProducts(
+          {
+            category: params.category,
+            condition: params.condition,
+            location: params.location,
+          },
+          productLimit
+        ),
     getCategories(),
   ]);
 

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -9,6 +9,7 @@ import {
   getProductsWithCount,
   getCategories,
   getAvailableLocations,
+  searchProducts,
   type ProductFilters,
   type ProductSort,
 } from '@/lib/services/products';
@@ -118,7 +119,10 @@ async function ProductsContent({ searchParams, categories, locations }: Products
     maxPrice,
   };
 
-  const { items, count } = await getProductsWithCount(filters, PAGE_SIZE, offset, sort);
+  const hasQuery = Boolean(filters.search && filters.search.trim().length > 0);
+  const { items, count } = hasQuery
+    ? await searchProducts(filters, PAGE_SIZE, offset, sort)
+    : await getProductsWithCount(filters, PAGE_SIZE, offset, sort);
 
   const boundedPage = count === 0 ? 1 : Math.min(currentPage, Math.max(1, Math.ceil(count / PAGE_SIZE)));
   const displayOffset = boundedPage === currentPage ? offset : (boundedPage - 1) * PAGE_SIZE;

--- a/src/lib/services/__tests__/searchProducts.test.ts
+++ b/src/lib/services/__tests__/searchProducts.test.ts
@@ -1,0 +1,223 @@
+import assert from 'node:assert/strict';
+import { mock, test } from 'node:test';
+import type { searchProducts as SearchProductsFn } from '../products';
+
+type SearchProducts = typeof SearchProductsFn;
+
+type SupabaseMock = {
+  functions: { invoke: ReturnType<typeof mock.fn> };
+  from: ReturnType<typeof mock.fn>;
+};
+
+const defaultCookies = {
+  getAll: () => [],
+  set: () => {},
+};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __supabaseClientMock: SupabaseMock | undefined;
+  // eslint-disable-next-line no-var
+  var __cookiesMock: typeof defaultCookies | undefined;
+}
+
+async function loadSearchProducts() {
+  const module = (await import('../products.js')) as { searchProducts: SearchProducts };
+  return module.searchProducts;
+}
+
+test('searchProducts normalizes edge results and fetches relations', async (t) => {
+  const invokeMock = mock.fn(async () => ({
+    data: {
+      items: [
+        {
+          id: 'product-1',
+          title: 'Smartphone',
+          description: 'Latest model',
+          price: '450000',
+          currency: 'IQD',
+          condition: 'new',
+          category_id: 'category-1',
+          seller_id: 'seller-1',
+          location: 'Erbil',
+          images: ['https://example.com/1.jpg'],
+          is_active: true,
+          is_sold: false,
+          is_promoted: false,
+          views: 120,
+          created_at: '2024-05-01T00:00:00.000Z',
+          updated_at: null,
+        },
+      ],
+      totalCount: 12,
+      limit: 24,
+      offset: 0,
+    },
+    error: null,
+  }));
+
+  const detailResponse = {
+    data: [
+      {
+        id: 'product-1',
+        title: 'Smartphone',
+        description: 'Latest model',
+        price: '450000',
+        currency: 'IQD',
+        condition: 'new',
+        category_id: 'category-1',
+        seller_id: 'seller-1',
+        location: 'Erbil',
+        images: ['https://example.com/1.jpg'],
+        is_active: true,
+        is_sold: false,
+        is_promoted: false,
+        views: 120,
+        created_at: '2024-05-01T00:00:00.000Z',
+        updated_at: null,
+        seller: {
+          id: 'seller-1',
+          email: 'seller@example.com',
+          phone: null,
+          full_name: 'Alice Seller',
+          avatar_url: null,
+          location: 'Erbil',
+          bio: null,
+          is_verified: true,
+          rating: 4.8,
+          total_ratings: 17,
+          created_at: '2024-01-01T00:00:00.000Z',
+          updated_at: '2024-01-02T00:00:00.000Z',
+        },
+        category: {
+          id: 'category-1',
+          name: 'Phones',
+          name_ar: null,
+          name_ku: null,
+          description: null,
+          icon: '📱',
+          is_active: true,
+          sort_order: 1,
+          created_at: '2024-01-10T00:00:00.000Z',
+        },
+      },
+    ],
+    error: null,
+  };
+
+  const inMock = mock.fn(async () => detailResponse);
+  const selectMock = mock.fn(() => ({ in: inMock }));
+  const fromMock = mock.fn(() => ({ select: selectMock }));
+
+  const supabaseClient: SupabaseMock = {
+    functions: { invoke: invokeMock },
+    from: fromMock,
+  };
+
+  globalThis.__supabaseClientMock = supabaseClient;
+  globalThis.__cookiesMock = defaultCookies;
+
+  t.after(() => {
+    delete globalThis.__supabaseClientMock;
+    delete globalThis.__cookiesMock;
+  });
+
+  const searchProducts = await loadSearchProducts();
+
+  const result = await searchProducts({ search: 'phone' }, 24, 0, 'newest');
+
+  assert.equal(result.count, 12);
+  assert.equal(result.items.length, 1);
+  const product = result.items[0];
+  assert.equal(product.id, 'product-1');
+  assert.equal(product.title, 'Smartphone');
+  assert.equal(product.price, 450000);
+  assert(product.seller);
+  assert.equal(product.seller?.fullName, 'Alice Seller');
+  assert.equal(product.category?.name, 'Phones');
+
+  assert.equal(invokeMock.mock.calls.length, 1);
+  const firstCall = invokeMock.mock.calls[0];
+  assert.ok(firstCall);
+  const callArgs = (firstCall as any).arguments;
+  assert.equal(callArgs[0], 'product-search');
+  assert.deepEqual(callArgs[1], {
+    body: {
+      query: 'phone',
+      categoryId: undefined,
+      minPrice: undefined,
+      maxPrice: undefined,
+      city: undefined,
+      limit: 24,
+      offset: 0,
+    },
+  });
+
+  assert.equal(fromMock.mock.calls.length, 1);
+  assert.equal(selectMock.mock.calls.length, 1);
+  assert.equal(inMock.mock.calls.length, 1);
+});
+
+test('searchProducts falls back to edge payload when relation query fails', async (t) => {
+  const invokeMock = mock.fn(async () => ({
+    data: {
+      items: [
+        {
+          id: 'product-2',
+          title: 'Headphones',
+          description: null,
+          price: 99000,
+          currency: 'IQD',
+          condition: 'used',
+          category_id: null,
+          seller_id: 'seller-2',
+          location: 'Sulaymaniyah',
+          images: [],
+          is_active: true,
+          is_sold: false,
+          is_promoted: false,
+          views: 12,
+          created_at: '2024-02-01T00:00:00.000Z',
+          updated_at: null,
+        },
+      ],
+      totalCount: '5',
+      limit: 24,
+      offset: 0,
+    },
+    error: null,
+  }));
+
+  const failingInMock = mock.fn(async () => ({ data: null, error: new Error('boom') }));
+  const selectMock = mock.fn(() => ({ in: failingInMock }));
+  const fromMock = mock.fn(() => ({ select: selectMock }));
+
+  const supabaseClient: SupabaseMock = {
+    functions: { invoke: invokeMock },
+    from: fromMock,
+  };
+
+  globalThis.__supabaseClientMock = supabaseClient;
+  globalThis.__cookiesMock = defaultCookies;
+
+  const consoleErrorMock = mock.method(console, 'error');
+
+  t.after(() => {
+    delete globalThis.__supabaseClientMock;
+    delete globalThis.__cookiesMock;
+    consoleErrorMock.mock.restore();
+  });
+
+  const searchProducts = await loadSearchProducts();
+
+  const result = await searchProducts({ search: 'audio' }, 24, 0, 'newest');
+
+  assert.equal(result.count, 5);
+  assert.equal(result.items.length, 1);
+  const product = result.items[0];
+  assert.equal(product.id, 'product-2');
+  assert.equal(product.title, 'Headphones');
+  assert.equal(product.seller, null);
+  assert.equal(product.category, null);
+  assert.equal(consoleErrorMock.mock.calls.length, 1);
+});

--- a/tools/test-stubs/alias-loader.mjs
+++ b/tools/test-stubs/alias-loader.mjs
@@ -1,0 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const stubMap = new Map([
+  ['@/utils/supabase/server', pathToFileURL(path.join(rootDir, 'tools', 'test-stubs', 'supabase-server.js')).href],
+  ['next/headers', pathToFileURL(path.join(rootDir, 'tools', 'test-stubs', 'next-headers.js')).href],
+]);
+
+export async function resolve(specifier, context, nextResolve) {
+  if (stubMap.has(specifier)) {
+    return { shortCircuit: true, url: stubMap.get(specifier) };
+  }
+
+  return nextResolve(specifier, context);
+}

--- a/tools/test-stubs/next-headers.js
+++ b/tools/test-stubs/next-headers.js
@@ -1,0 +1,8 @@
+export async function cookies() {
+  return (
+    globalThis.__cookiesMock ?? {
+      getAll: () => [],
+      set: () => {},
+    }
+  );
+}

--- a/tools/test-stubs/supabase-server.js
+++ b/tools/test-stubs/supabase-server.js
@@ -1,0 +1,7 @@
+export async function createClient() {
+  const client = globalThis.__supabaseClientMock;
+  if (!client) {
+    throw new Error('Supabase client mock not set. Did you forget to assign globalThis.__supabaseClientMock?');
+  }
+  return client;
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-tests",
+    "declaration": false,
+    "emitDeclarationOnly": false,
+    "sourceMap": false
+  },
+  "include": [
+    "src/lib/services/products.ts",
+    "src/lib/services/__tests__/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a server-side `searchProducts` helper that invokes the `product-search` edge function and normalizes results
- update the homepage and `/products` route to use the edge search path when queries are present and return edge pagination totals
- document the integration and add smoke tests plus loaders that stub Supabase and Next headers for Node's test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fa14896fec832ca6e0b9e288082365